### PR TITLE
add support for rgb565

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,7 @@ delan@azabani.com</a>.
 					<li><label><input type="radio" name="cons" value="Byte class (zeroes/ones/ASCII/other)" checked></label>
 					<li><label><input type="radio" name="cons" value="Bit value as monochrome"></label>
 					<li><label><input type="radio" name="cons" value="Byte value as gray level"></label>
+					<li><label><input type="radio" name="cons" value="RGB565"></label>
 					<li><label><input type="radio" name="cons" value="RGB"></label>
 					<li><label><input type="radio" name="cons" value="BGR"></label>
 					<li><label><input type="radio" name="cons" value="RGBA"></label>
@@ -251,6 +252,18 @@ var cons = {
 			while (i.data) {
 				x = nextbyte(i);
 				p(x, x, x, opt.alpha);
+			}
+		};
+	},
+	'RGB565': function(i, o, p, opt) {
+		var s = 0, word;
+		return function() {
+			while (i.data) {
+				x = nextbyte(i);
+				switch (s) {
+				case 0: word = x; s++; break;
+				case 1: word = (word << 8) | x; p(((word >> 11) & 0x1f) << 3, ((word >> 5) & 0x3f) << 2, (word & 0x1f) << 3, opt.alpha); s = 0;
+				}
 			}
 		};
 	},


### PR DESCRIPTION
rgb565 is common in embedded systems with LCDs. the red, green and blue channels are packed into a single 16-bit value, with 5 bits dedicated to red, 6 bits dedicated to green, and 5 bits dedicated to blue.

this commit adds support for rgb565. the channel intensities are shifted to span /most/ of the 8-bit range, reaching `11111000` for red/blue and `11111100` for green. at present, the data is assumed to be little endian. we could add two new modes, instead of just one - rgb565 LE and rgb565 BE, but this is enough for me atm.

woof :3